### PR TITLE
Fix crash when starting a new local game

### DIFF
--- a/polyclash/gui/dialogs.py
+++ b/polyclash/gui/dialogs.py
@@ -61,7 +61,7 @@ class LocalGameDialog(QDialog):
         controller.set_mode(LOCAL)
         controller.add_player(BLACK, kind=HUMAN if black_kind == "Human" else AI)
         controller.add_player(WHITE, kind=HUMAN if white_kind == "Human" else AI)
-        controller.start_game()
+        controller.start()
         self.window.update()
         self.close()
 

--- a/tests/integration/test_ui_logic.py
+++ b/tests/integration/test_ui_logic.py
@@ -4,6 +4,9 @@ from PyQt5.QtCore import Qt
 from polyclash.gui.main import MainWindow
 from polyclash.game.controller import SphericalGoController
 from polyclash.game.board import BLACK, WHITE
+from polyclash.gui.dialogs import LocalGameDialog
+from polyclash.game.player import HUMAN, AI
+from polyclash.game.controller import LOCAL
 
 # Check if running in CI environment
 is_ci = os.environ.get('CI') == 'true'
@@ -83,3 +86,29 @@ class TestUILogicIntegration:
         # Check that the UI is updated
         assert main_window.update_status.called
         assert controller.board.current_player == WHITE
+
+    @pytest.mark.skipif(is_ci, reason="Skip UI tests in CI environment to avoid core dumps")
+    def test_start_local_game_no_crash(self, qapp, qtbot):
+        """Test starting a local game via the dialog doesn't crash and sets up correctly."""
+        controller = SphericalGoController()
+        main_window = MainWindow(controller=controller)
+        qtbot.addWidget(main_window)
+
+        dialog = LocalGameDialog(parent=main_window)
+        qtbot.addWidget(dialog)
+        dialog.show()
+
+        qtbot.waitUntil(dialog.isVisible, timeout=1000)
+        qtbot.waitUntil(dialog.isActiveWindow, timeout=1000)
+
+        qtbot.mouseClick(dialog.start_button, Qt.LeftButton)
+
+        qtbot.waitUntil(lambda: not dialog.isVisible(), timeout=1000)
+
+        assert controller.mode == LOCAL
+        assert controller.players[BLACK].kind == HUMAN
+        assert controller.players[WHITE].kind == HUMAN
+        assert controller.board.counter == 0
+        assert controller.board.current_player == BLACK
+
+        main_window.close()


### PR DESCRIPTION
The client was crashing when you tried to start a new local game by clicking the 'Start' button in the 'New Local Game' dialog.

This was due to an AttributeError: the dialog was attempting to call `controller.start_game()`, but the method on the SphericalGoController is named `start()`.

This commit corrects the method call from `start_game()` to `start()` in `polyclash/gui/dialogs.py`.

An integration test (`test_start_local_game_no_crash`) has been added to `tests/integration/test_ui_logic.py` to verify that opening the dialog, clicking start, and the subsequent game initialization works correctly without crashing. The test also confirms that the controller's mode, players, and board state are set up as expected.